### PR TITLE
Lecture 6 - fix Proto file path typo and protoc-gen-go import path

### DIFF
--- a/lecture6_eng.md
+++ b/lecture6_eng.md
@@ -75,7 +75,7 @@ the package where generated code will be stored. Just add line
 ```protobuf
 syntax = "proto3";
 
-option go_package = ".;pb";
+option go_package = "./pb";
 
 message CPU {
   // Brand of the CPU

--- a/lecture6_eng.md
+++ b/lecture6_eng.md
@@ -115,7 +115,7 @@ go get -u google.golang.org/grpc
 and second, the `protoc-gen-go` library
 
 ```shell
-go get -u github.com/golang/protobuf/protoc-gen-go
+go get -u google.golang.org/protobuf/cmd/protoc-gen-go
 ```
 
 Now we are all set to generate Go codes, I will create a new folder named `pb` 


### PR DESCRIPTION
1. The current proto file gives the below error:
    ```
    protoc-gen-go: invalid Go import path "." for "processor_message.proto"
    
    The import path must contain at least one forward slash ('/') character.
    
    See https://developers.google.com/protocol-buffers/docs/reference/go-generated#package for more information.
    
    --go_out: protoc-gen-go: Plugin failed with status code 1.
    ```

    Changing `".;pb";` to `"./pb";` fixed it.

2. The go import path for `protoc-gen-go` has now changed. Updating the new path.